### PR TITLE
fix: lsp server package deprecation

### DIFF
--- a/lsp/likec4.lua
+++ b/lsp/likec4.lua
@@ -1,13 +1,13 @@
 return {
-  -- The command to start the language server.
-  -- This assumes 'likec4-language-server' is in your system's PATH.
-  cmd = { "likec4-language-server", "--stdio" },
+	-- The command to start the language server.
+	-- This assumes 'likec4' is in your system's PATH.
+	cmd = { "likec4", "lsp", "--stdio" },
 
-  -- The filetypes for which this server should be enabled.
-  filetypes = { "likec4" },
+	-- The filetypes for which this server should be enabled.
+	filetypes = { "likec4" },
 
-  -- Root markers used to find the project root.
-  -- The language server will only attach to a project
-  -- if one of these files exists in an ancestor directory.
-  root_markers = { "likec4.config.json", ".git" },
+	-- Root markers used to find the project root.
+	-- The language server will only attach to a project
+	-- if one of these files exists in an ancestor directory.
+	root_markers = { "likec4.config.json", ".git" },
 }

--- a/readme.md
+++ b/readme.md
@@ -14,14 +14,13 @@ Using lazy.nvim:
 ```lua
 {
  'likec4/likec4.nvim',
-  build = 'npm install -g @likec4/language-server'
+  build = 'npm install -g likec4'
 }
 ```
 
 ## Usage
 
 The plugin automatically detects `likec4` files (e.g., `file.c4`) and applies syntax highlighting and LSP features.
-
 
 ## License
 


### PR DESCRIPTION
The default plugin configuration still relies on the deprecated @likec4/language-server package, which now returns the following error

```
This package is not available as a standalone LSP server. Use `likec4 lsp` instead.
```

The fix:
- replaces @likec4/language-server with the`likec4 lsp` command
- requires the likec4 package to be installed globally as part of the plugin build command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated language server command initialization to align with new package structure
  * Updated installation documentation to reflect new package naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->