### PR TITLE
use likec4-lsp as the LSP command

### DIFF
--- a/lsp/likec4.lua
+++ b/lsp/likec4.lua
@@ -1,7 +1,8 @@
 return {
 	-- The command to start the language server.
-	-- This assumes 'likec4' is in your system's PATH.
-	cmd = { "likec4", "lsp", "--stdio" },
+	-- This assumes 'likec4-lsp' is in your system's PATH.
+	-- https://likec4.dev/tooling/editors/#standalone-language-server
+	cmd = { "likec4-lsp", "--stdio" },
 
 	-- The filetypes for which this server should be enabled.
 	filetypes = { "likec4" },


### PR DESCRIPTION
By the documentation `likec4-lsp` is the command to use. Tested on my machine - running 
`npm install -g @likec4/lsp` added the `likec4-lsp` command, and using that in this plugin made the LSP attach properly